### PR TITLE
 Use `path.sep` for path splitting and joining

### DIFF
--- a/packages/template-core/scripts/copyProjectFiles.js
+++ b/packages/template-core/scripts/copyProjectFiles.js
@@ -97,9 +97,9 @@ module.exports = function copyProjectFiles({
             extname,
             basename: basename === 'gitignore' ? '.gitignore' : basename.replace(REGEXP_SUFFIX, ''),
             dirname: dirname
-              .split('/')
+              .split(path.sep)
               .map((item) => item.replace(REGEXP_SUFFIX, ''))
-              .join('/'),
+              .join(path.sep),
           };
         })
       )


### PR DESCRIPTION
for operating systems that do not use `/` as path separator, the hard coded `/` in `split('/')` will not split a path correctly.  
for example, on windows, the path `scripts($-u)\templates`  will not be splitted into `['scripts($-u)', 'templates']` but `['scripts($-u)\templates']` instead.