### PR TITLE
fix(vue-template):windows add component error

### DIFF
--- a/packages/template-core/vue/scripts($-l)/add-component.js
+++ b/packages/template-core/vue/scripts($-l)/add-component.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const fs = require('fs-extra');
 const fg = require('fast-glob');
+const os = require('os');
 
 const componentName = process.argv[2];
 const templatePath = path.resolve(__dirname, 'template');
@@ -18,6 +19,8 @@ if (fs.pathExistsSync(targetComponentPath)) {
 }
 
 const replaceContent = async (pattern, searchValue, replaceValue) => {
+  if (os.platform() === 'win32') pattern = pattern.replace(/\\/g, '/');
+
   const files = await fg(pattern);
   const regExp = new RegExp(searchValue, 'g');
 


### PR DESCRIPTION
在windows平台上会因为路径问题导致新增的组件无法正确的替换内容，此pr修复了这个问题
![image](https://user-images.githubusercontent.com/48681136/187401362-64bd3cd5-ac4b-488a-ba92-2cd3a3009880.png)
